### PR TITLE
Remove MachineShopSimulator Message Chains

### DIFF
--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -30,6 +30,11 @@ class Job {
         return theTime;
     }
 
+    public int getMachineNumber() {
+       int machineNumber = ((Task) getTaskQ().getFrontElement()).getMachine();
+       return machineNumber;
+    }
+
     public LinkedQueue getTaskQ() {
         return taskQ;
     }

--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -18,21 +18,21 @@ class Job {
 
     // other methods
     public void addTask(int theMachine, int theTime) {
-        getTaskQ().put(new Task(theMachine, theTime));
+        taskQ.put(new Task(theMachine, theTime));
     }
 
     /**
      * remove next task of job and return its time also update length
      */
     public int removeNextTask() {
-        int theTime = ((Task) getTaskQ().remove()).getTime();
+        int theTime = ((Task) taskQ.remove()).getTime();
         length = getLength() + theTime;
         return theTime;
     }
 
     public int getMachineNumber() {
-       int machineNumber = ((Task) getTaskQ().getFrontElement()).getMachine();
-       return machineNumber;
+      int machineNumber = ((Task) taskQ.getFrontElement()).getMachine();
+      return machineNumber;
     }
 
     public LinkedQueue getTaskQ() {

--- a/src/applications/Machine.java
+++ b/src/applications/Machine.java
@@ -51,6 +51,10 @@ class Machine {
         this.activeJob = activeJob;
     }
 
+    public void addJob(Job job) {
+        getJobQ().put(job);
+    }
+
     /**
      * change the state of theMachine
      *
@@ -80,9 +84,5 @@ class Machine {
         }
 
         return lastJob;
-    }
-
-    public void addJob(Job theJob) {
-        getJobQ().put(theJob);
     }
 }

--- a/src/applications/Machine.java
+++ b/src/applications/Machine.java
@@ -81,4 +81,8 @@ class Machine {
 
         return lastJob;
     }
+
+    public void addJob(Job theJob) {
+        getJobQ().put(theJob);
+    }
 }

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -29,7 +29,7 @@ public class MachineShopSimulator {
             return false;
         } else {// theJob has a next task
                 // get machine for next task
-            int p = ((Task) theJob.getTaskQ().getFrontElement()).getMachine();
+            int p = theJob.getMachineNumber();
             // put on machine p's wait queue
             machine[p].getJobQ().put(theJob);
             theJob.setArrivalTime(timeNow);

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -81,13 +81,13 @@ public class MachineShopSimulator {
             // create the job
             theJob = new Job(i);
             for (int j = 1; j <= tasks; j++) {
-                int theMachine = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+1];
-                int theTaskTime = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+2];
+                int theMachine = specification.getMachineForJobTask(i,j);
+                int theTaskTime = specification.getTimeForJobTask(i,j);
                 if (j == 1)
                     firstMachine = theMachine; // job's first machine
                 theJob.addTask(theMachine, theTaskTime); // add to
             } // task queue
-            MachineShopSimulator.machine[firstMachine].getJobQ().put(theJob);
+            machine[firstMachine].addJob(theJob);
         }
     }
 

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -29,13 +29,13 @@ public class MachineShopSimulator {
             return false;
         } else {// theJob has a next task
                 // get machine for next task
-            int p = theJob.getMachineNumber();
-            // put on machine p's wait queue
-            machine[p].addJob(theJob);
+            int machineNumber = theJob.getMachineNumber();
+            // put on this machine's wait queue
+            machine[machineNumber].addJob(theJob);
             theJob.setArrivalTime(timeNow);
-            // if p idle, schedule immediately
-            if (eList.nextEventTime(p) == largeTime) {// machine is idle
-                machine[p].changeState(eList, p, timeNow);
+            // if this machine is idle, schedule immediately
+            if (eList.nextEventTime(machineNumber) == largeTime) {// machine is idle
+                machine[machineNumber].changeState(eList, machineNumber, timeNow);
             }
             return true;
         }
@@ -74,18 +74,20 @@ public class MachineShopSimulator {
     static void setUpJobs(SimulationSpecification specification) {
         // input the jobs
         Job theJob;
+        // i represents a jobNumber
         for (int i = 1; i <= specification.getNumJobs(); i++) {
-            int tasks = specification.getJobTasks(i);
+            int taskNum = specification.getNumTasksInJob(i);
             int firstMachine = 0; // machine for first task
 
             // create the job
             theJob = new Job(i);
-            for (int j = 1; j <= tasks; j++) {
-                int theMachine = specification.getMachineForJobTask(i,j);
-                int theTaskTime = specification.getTimeForJobTask(i,j);
+            // j represents a taskNumber
+            for (int j = 1; j <= taskNum; j++) {
+                int machine = specification.getMachineForJobTask(i,j);
+                int taskTime = specification.getTimeForJobTask(i,j);
                 if (j == 1)
-                    firstMachine = theMachine; // job's first machine
-                theJob.addTask(theMachine, theTaskTime); // add to
+                    firstMachine = machine; // job's first machine
+                theJob.addTask(machine, taskTime); // add to
             } // task queue
             machine[firstMachine].addJob(theJob);
         }

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -31,7 +31,7 @@ public class MachineShopSimulator {
                 // get machine for next task
             int p = theJob.getMachineNumber();
             // put on machine p's wait queue
-            machine[p].getJobQ().put(theJob);
+            machine[p].addJob(theJob);
             theJob.setArrivalTime(timeNow);
             // if p idle, schedule immediately
             if (eList.nextEventTime(p) == largeTime) {// machine is idle
@@ -75,7 +75,7 @@ public class MachineShopSimulator {
         // input the jobs
         Job theJob;
         for (int i = 1; i <= specification.getNumJobs(); i++) {
-            int tasks = specification.getJobSpecifications(i).getNumTasks();
+            int tasks = specification.getJobTasks(i);
             int firstMachine = 0; // machine for first task
 
             // create the job

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -1,5 +1,7 @@
 package applications;
 
+import exceptions.MyInputException;
+
 import java.util.Arrays;
 
 public class SimulationSpecification {
@@ -47,6 +49,14 @@ public class SimulationSpecification {
     public int getJobTasks(int jobNumber) {
         int numTasks = getJobSpecifications(jobNumber).getNumTasks();
         return numTasks;
+    }
+
+    public int getMachineForJobTask(int jobNumber, int taskNumber) {
+        return getJobSpecifications(jobNumber).getSpecificationsForTasks()[2*(taskNumber-1)+1];
+    }
+
+    public int getTimeForJobTask(int jobNumber, int taskNumber) {
+        return getJobSpecifications(jobNumber).getSpecificationsForTasks()[2*(taskNumber-1)+2];
     }
 
     @Override

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -46,7 +46,7 @@ public class SimulationSpecification {
         return jobSpecifications[jobNumber];
     }
 
-    public int getJobTasks(int jobNumber) {
+    public int getNumTasksInJob(int jobNumber) {
         int numTasks = getJobSpecifications(jobNumber).getNumTasks();
         return numTasks;
     }

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -44,6 +44,11 @@ public class SimulationSpecification {
         return jobSpecifications[jobNumber];
     }
 
+    public int getJobTasks(int jobNumber) {
+        int numTasks = getJobSpecifications(jobNumber).getNumTasks();
+        return numTasks;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
This pull request addresses #7 

The `MachineShopSimulator` class contains numerous instances of the message chain smell. We think the message chains are significantly affecting the clarity of this class, so they should be removed. The chains that we addressed could be found in the two methods `setUpJobs` and `moveToNextMachine` Most of the commits in this request targeted these message chains by creating new functions in the classes whose methods and fields were invoked, and then calling these methods instead.

* Commit 6c49e34 creates a new method in the Job class to retrieve the first machine from the JobQ, and `MachineShopSimulator` now calls this method.

* Commit 1da1c39 creates two new methods to get rid of message chains, `addJob` in the `Machine` class, and `getJobTasks` in the `SimulationSpecification` class that are both called in `MachineShopSimulator`.

* Commit 5e1a037 creates two new methods named `getMachineForJobTask` and `getTimeForJobTask` in the class `SimulationSpecification` that are now called in `MachineShopSimulator` instead of using the message chain version of having the same functionality.

* Commit d913a23 splits up the message chain in the `Job` class that was moved in 6c49e34 so that the code is more readable.
