### PR TITLE
Refactor read job specifications method

### DIFF
--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -30,6 +30,11 @@ class Job {
         return theTime;
     }
 
+    public int getMachineNumber() {
+       int machineNumber = ((Task) getTaskQ().getFrontElement()).getMachine();
+       return machineNumber;
+    }
+
     public LinkedQueue getTaskQ() {
         return taskQ;
     }

--- a/src/applications/Machine.java
+++ b/src/applications/Machine.java
@@ -81,4 +81,8 @@ class Machine {
 
         return lastJob;
     }
+
+    public void addJob(Job theJob) {
+        getJobQ().put(theJob);
+    }
 }

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -29,7 +29,7 @@ public class MachineShopSimulator {
             return false;
         } else {// theJob has a next task
                 // get machine for next task
-            int p = ((Task) theJob.getTaskQ().getFrontElement()).getMachine();
+            int p = theJob.getMachineNumber();
             // put on machine p's wait queue
             machine[p].getJobQ().put(theJob);
             theJob.setArrivalTime(timeNow);

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -81,13 +81,13 @@ public class MachineShopSimulator {
             // create the job
             theJob = new Job(i);
             for (int j = 1; j <= tasks; j++) {
-                int theMachine = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+1];
-                int theTaskTime = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+2];
+                int theMachine = specification.getMachineForJobTask(i,j);
+                int theTaskTime = specification.getTimeForJobTask(i,j);
                 if (j == 1)
                     firstMachine = theMachine; // job's first machine
                 theJob.addTask(theMachine, theTaskTime); // add to
             } // task queue
-            MachineShopSimulator.machine[firstMachine].getJobQ().put(theJob);
+            machine[firstMachine].addJob(theJob);
         }
     }
 

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -31,7 +31,7 @@ public class MachineShopSimulator {
                 // get machine for next task
             int p = theJob.getMachineNumber();
             // put on machine p's wait queue
-            machine[p].getJobQ().put(theJob);
+            machine[p].addJob(theJob);
             theJob.setArrivalTime(timeNow);
             // if p idle, schedule immediately
             if (eList.nextEventTime(p) == largeTime) {// machine is idle
@@ -75,7 +75,7 @@ public class MachineShopSimulator {
         // input the jobs
         Job theJob;
         for (int i = 1; i <= specification.getNumJobs(); i++) {
-            int tasks = specification.getJobSpecifications(i).getNumTasks();
+            int tasks = specification.getJobTasks(i);
             int firstMachine = 0; // machine for first task
 
             // create the job

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -1,5 +1,7 @@
 package applications;
 
+import exceptions.MyInputException;
+
 import java.util.Arrays;
 
 public class SimulationSpecification {
@@ -47,6 +49,14 @@ public class SimulationSpecification {
     public int getJobTasks(int jobNumber) {
         int numTasks = getJobSpecifications(jobNumber).getNumTasks();
         return numTasks;
+    }
+
+    public int getMachineForJobTask(int jobNumber, int taskNumber) {
+        return getJobSpecifications(jobNumber).getSpecificationsForTasks()[2*(taskNumber-1)+1];
+    }
+
+    public int getTimeForJobTask(int jobNumber, int taskNumber) {
+        return getJobSpecifications(jobNumber).getSpecificationsForTasks()[2*(taskNumber-1)+2];
     }
 
     @Override

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -44,6 +44,11 @@ public class SimulationSpecification {
         return jobSpecifications[jobNumber];
     }
 
+    public int getJobTasks(int jobNumber) {
+        int numTasks = getJobSpecifications(jobNumber).getNumTasks();
+        return numTasks;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/src/applications/SpecificationReader.java
+++ b/src/applications/SpecificationReader.java
@@ -30,11 +30,15 @@ public class SpecificationReader {
 
     private void readJobSpecifications() {
         // input the jobs
-        JobSpecification[] jobSpecifications = new JobSpecification[specification.getNumJobs()+1];
-        for (int i=1; i <= specification.getNumJobs(); i++) {
+        JobSpecification[] jobSpecifications = new JobSpecification[specification.getNumJobs() + 1];
+        for (int i = 1; i <= specification.getNumJobs(); i++) {
             jobSpecifications[i] = new JobSpecification();
         }
         specification.setJobSpecification(jobSpecifications);
+        readNumTasksForJobs(jobSpecifications);
+    }
+
+    private void readNumTasksForJobs(JobSpecification[] jobSpecifications) {
         for (int i = 1; i <= specification.getNumJobs(); i++) {
             System.out.println("Enter number of tasks for job " + i);
             int tasks = keyboard.readInteger(); // number of tasks
@@ -46,16 +50,21 @@ public class SpecificationReader {
 
             System.out.println("Enter the tasks (machine, time)"
                     + " in process order");
-            for (int j = 1; j <= tasks; j++) { // get tasks for job i
-                int theMachine = keyboard.readInteger();
-                int theTaskTime = keyboard.readInteger();
-                if (theMachine < 1 || theMachine > specification.getNumMachines()
-                        || theTaskTime < 1)
-                    throw new MyInputException(MachineShopSimulator.BAD_MACHINE_NUMBER_OR_TASK_TIME);
-                specificationsForTasks[2*(j-1)+1] = theMachine;
-                specificationsForTasks[2*(j-1)+2] = theTaskTime;
-            }
+            readTasks(tasks, specificationsForTasks);
             specification.setSpecificationsForTasks(i, specificationsForTasks);
+        }
+
+    }
+
+    private void readTasks(int tasks, int[] specificationsForTasks) {
+        for (int j = 1; j <= tasks; j++) { // get tasks for job i
+            int theMachine = keyboard.readInteger();
+            int theTaskTime = keyboard.readInteger();
+            if (theMachine < 1 || theMachine > specification.getNumMachines()
+                    || theTaskTime < 1)
+                throw new MyInputException(MachineShopSimulator.BAD_MACHINE_NUMBER_OR_TASK_TIME);
+            specificationsForTasks[2*(j-1)+1] = theMachine;
+            specificationsForTasks[2*(j-1)+2] = theTaskTime;
         }
     }
 


### PR DESCRIPTION
This pull request is conditional on the acceptance of PR #11.

We are proposing changes to the `readJobSpecifications` method in the `SpecificationReader` class because it is long and difficult to follow. To address this problem, we've split it up into two helper methods named `readTasks` and `readNumTasksForJobs` which should improve readability by showing what different segments of the code are responsible for. In the original function, there were nested loops that would read information about the specifications that the user inputs, and we separated the function at the points where the longer loops began.

Addresses #8